### PR TITLE
fix: 자동 로그인 문제, 자동 닉네이, 토큰 이슈 해결

### DIFF
--- a/src/main/java/com/team/leaf/user/account/controller/AccountController.java
+++ b/src/main/java/com/team/leaf/user/account/controller/AccountController.java
@@ -2,9 +2,7 @@ package com.team.leaf.user.account.controller;
 
 import com.team.leaf.user.account.dto.common.DuplicateEmailRequest;
 import com.team.leaf.user.account.dto.common.DuplicatePhoneRequest;
-import com.team.leaf.user.account.dto.request.jwt.AdditionalJoinInfoRequest;
-import com.team.leaf.user.account.dto.request.jwt.JwtJoinRequest;
-import com.team.leaf.user.account.dto.request.jwt.JwtLoginRequest;
+import com.team.leaf.user.account.dto.request.jwt.*;
 import com.team.leaf.user.account.dto.response.LoginAccountDto;
 import com.team.leaf.user.account.dto.response.TokenDto;
 import com.team.leaf.user.account.exception.ApiResponse;

--- a/src/main/java/com/team/leaf/user/account/controller/AccountController.java
+++ b/src/main/java/com/team/leaf/user/account/controller/AccountController.java
@@ -52,23 +52,25 @@ public class AccountController {
 
     @DeleteMapping("/logout")
     @Operation(summary = "자체 로그인 로그아웃 API")
-    public ApiResponse<String> logout(@RequestHeader(name = JwtTokenUtil.ACCESS_TOKEN, required = false) String accessToken) {
-        return new ApiResponse<>(accountService.logout(accessToken));
+    public ApiResponse<String> logout(@RequestHeader(name = JwtTokenUtil.ACCESS_TOKEN) String accessToken,
+                                      @RequestHeader(name = JwtTokenUtil.REFRESH_TOKEN) String refreshToken) {
+        return new ApiResponse<>(accountService.logout(accessToken, refreshToken));
     }
 
     @PostMapping("/issue/token")
     @Operation(summary= "Access Token 갱신 API")
     public ResponseEntity<?> refreshAccessToken(HttpServletRequest request, HttpServletResponse response,
-                                                @RequestHeader(name = JwtTokenUtil.REFRESH_TOKEN, required = false) String refreshToken) {
+                                                @RequestHeader(name = JwtTokenUtil.REFRESH_TOKEN, required = false) String refreshToken,
+                                                @RequestBody PlatformRequest platformRequest ) {
         try {
             TokenDto newTokenDto = null;
 
             if(refreshToken == null) {
                 String cookie_refreshToken = JwtTokenFilter.getTokenByRequest(request, "refreshToken");
 
-                newTokenDto = accountService.refreshAccessToken(cookie_refreshToken);
+                newTokenDto = accountService.refreshAccessToken(platformRequest.getPlatform(), cookie_refreshToken);
             } else {
-                newTokenDto = accountService.refreshAccessToken(refreshToken);
+                newTokenDto = accountService.refreshAccessToken(platformRequest.getPlatform(), refreshToken);
             }
 
             commonService.setHeader(response, newTokenDto);

--- a/src/main/java/com/team/leaf/user/account/controller/AppOAuth2Controller.java
+++ b/src/main/java/com/team/leaf/user/account/controller/AppOAuth2Controller.java
@@ -1,5 +1,6 @@
 package com.team.leaf.user.account.controller;
 
+import com.team.leaf.user.account.dto.request.jwt.Platform;
 import com.team.leaf.user.account.dto.request.oauth.OAuth2LoginType;
 import com.team.leaf.user.account.dto.response.OAuth2LoginResponse;
 import com.team.leaf.user.account.dto.response.TokenDto;
@@ -23,8 +24,8 @@ public class AppOAuth2Controller {
 
     @PostMapping("/login")
     @Operation(summary = "[앱 전용] 소셜 로그인 로그인 API")
-    public OAuth2LoginResponse login(@RequestParam(name = "type") OAuth2LoginType type, @RequestParam(name = "accessToken") String accessToken, HttpServletResponse response) {
-        return oAuthService.oAuth2Login(type, accessToken, response);
+    public OAuth2LoginResponse login(@RequestParam Platform platform, @RequestParam(name = "type") OAuth2LoginType type, @RequestParam(name = "accessToken") String accessToken, HttpServletResponse response) {
+        return oAuthService.oAuth2Login(platform, type, accessToken, response);
     }
 
     @DeleteMapping("/logout")
@@ -35,10 +36,10 @@ public class AppOAuth2Controller {
 
     @PostMapping("/issue/token")
     @Operation(summary= "Access Token 갱신 API")
-    public ResponseEntity<?> refreshAccessToken(@RequestHeader(name = JwtTokenUtil.ACCESS_TOKEN, required = false) String accessToken,
+    public ResponseEntity<?> refreshAccessToken(@RequestBody Platform request,
                                                 @RequestHeader(name = JwtTokenUtil.REFRESH_TOKEN, required = false) String refreshToken) {
         try {
-            TokenDto newTokenDto = oAuthService.refreshAccessToken(accessToken, refreshToken);
+            TokenDto newTokenDto = oAuthService.refreshAccessToken(request, refreshToken);
 
             HttpHeaders headers = new HttpHeaders();
             headers.add(JwtTokenUtil.ACCESS_TOKEN, newTokenDto.getAccessToken());

--- a/src/main/java/com/team/leaf/user/account/controller/WebOAuth2Controller.java
+++ b/src/main/java/com/team/leaf/user/account/controller/WebOAuth2Controller.java
@@ -1,6 +1,7 @@
 package com.team.leaf.user.account.controller;
 
 import com.team.leaf.user.account.dto.request.oauth.OAuth2LoginType;
+import com.team.leaf.user.account.dto.request.oauth.OAuthLoginRequest;
 import com.team.leaf.user.account.dto.response.OAuth2LoginResponse;
 import com.team.leaf.user.account.dto.response.TokenDto;
 import com.team.leaf.user.account.exception.ApiResponse;
@@ -23,8 +24,8 @@ public class WebOAuth2Controller {
 
     @PostMapping("/login")
     @Operation(summary = "[웹 전용] 소셜 로그인 로그인 API")
-    public OAuth2LoginResponse login(@RequestParam(name = "type") OAuth2LoginType type, @RequestParam(name = "code") String code, HttpServletResponse response) {
-        return oAuthService.oAuth2Login(type, code, response);
+    public OAuth2LoginResponse login(@RequestBody OAuthLoginRequest request, HttpServletResponse response) {
+        return oAuthService.oAuth2Login(request, response);
     }
 
     @DeleteMapping("/logout")
@@ -35,10 +36,9 @@ public class WebOAuth2Controller {
 
     @PostMapping("/issue/token")
     @Operation(summary= "Access Token 갱신 API")
-    public ResponseEntity<?> refreshAccessToken(@RequestHeader(name = JwtTokenUtil.ACCESS_TOKEN, required = false) String accessToken,
-                                                @RequestHeader(name = JwtTokenUtil.REFRESH_TOKEN, required = false) String refreshToken) {
+    public ResponseEntity<?> refreshAccessToken(@RequestBody @RequestHeader(name = JwtTokenUtil.REFRESH_TOKEN, required = false) String refreshToken) {
         try {
-            TokenDto newTokenDto = oAuthService.refreshAccessToken(accessToken, refreshToken);
+            TokenDto newTokenDto = oAuthService.refreshAccessToken(refreshToken);
 
             HttpHeaders headers = new HttpHeaders();
             headers.add(JwtTokenUtil.ACCESS_TOKEN, newTokenDto.getAccessToken());

--- a/src/main/java/com/team/leaf/user/account/controller/WebOAuth2Controller.java
+++ b/src/main/java/com/team/leaf/user/account/controller/WebOAuth2Controller.java
@@ -30,8 +30,9 @@ public class WebOAuth2Controller {
 
     @DeleteMapping("/logout")
     @Operation(summary = "소셜 로그인 로그아웃 API")
-    public ApiResponse<String> logout(@RequestHeader(name = JwtTokenUtil.ACCESS_TOKEN, required = false) String accessToken) {
-        return new ApiResponse<>(oAuthService.logout(accessToken));
+    public ApiResponse<String> logout(@RequestHeader(name = JwtTokenUtil.ACCESS_TOKEN) String accessToken,
+                                      @RequestHeader(name = JwtTokenUtil.REFRESH_TOKEN) String refreshToken) {
+        return new ApiResponse<>(oAuthService.logout(accessToken, refreshToken));
     }
 
     @PostMapping("/issue/token")

--- a/src/main/java/com/team/leaf/user/account/controller/WebOAuth2Controller.java
+++ b/src/main/java/com/team/leaf/user/account/controller/WebOAuth2Controller.java
@@ -1,13 +1,17 @@
 package com.team.leaf.user.account.controller;
 
+import com.team.leaf.user.account.dto.request.jwt.PlatformRequest;
 import com.team.leaf.user.account.dto.request.oauth.OAuth2LoginType;
 import com.team.leaf.user.account.dto.request.oauth.OAuthLoginRequest;
 import com.team.leaf.user.account.dto.response.OAuth2LoginResponse;
 import com.team.leaf.user.account.dto.response.TokenDto;
 import com.team.leaf.user.account.exception.ApiResponse;
+import com.team.leaf.user.account.jwt.JwtTokenFilter;
 import com.team.leaf.user.account.jwt.JwtTokenUtil;
+import com.team.leaf.user.account.service.CommonService;
 import com.team.leaf.user.account.service.WebOAuth2Service;
 import io.swagger.v3.oas.annotations.Operation;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
@@ -21,6 +25,7 @@ import org.springframework.web.bind.annotation.*;
 public class WebOAuth2Controller {
 
     private final WebOAuth2Service oAuthService;
+    private final CommonService commonService;
 
     @PostMapping("/login")
     @Operation(summary = "[웹 전용] 소셜 로그인 로그인 API")
@@ -37,15 +42,22 @@ public class WebOAuth2Controller {
 
     @PostMapping("/issue/token")
     @Operation(summary= "Access Token 갱신 API")
-    public ResponseEntity<?> refreshAccessToken(@RequestBody @RequestHeader(name = JwtTokenUtil.REFRESH_TOKEN, required = false) String refreshToken) {
+    public ResponseEntity<?> refreshAccessToken(HttpServletRequest request, HttpServletResponse response,
+                                                @RequestBody @RequestHeader(name = JwtTokenUtil.REFRESH_TOKEN, required = false) String refreshToken,
+                                                @RequestBody PlatformRequest platformRequest) {
+        TokenDto newTokenDto = null;
         try {
-            TokenDto newTokenDto = oAuthService.refreshAccessToken(refreshToken);
+            if(refreshToken == null) {
+                String cookie_refreshToken = JwtTokenFilter.getTokenByRequest(request, "refreshToken");
 
-            HttpHeaders headers = new HttpHeaders();
-            headers.add(JwtTokenUtil.ACCESS_TOKEN, newTokenDto.getAccessToken());
-            headers.add(JwtTokenUtil.REFRESH_TOKEN, newTokenDto.getRefreshToken());
+                newTokenDto = oAuthService.refreshAccessToken(platformRequest.getPlatform(), cookie_refreshToken);
+            } else {
+                newTokenDto = oAuthService.refreshAccessToken(platformRequest.getPlatform(), refreshToken);
+            }
 
-            return new ResponseEntity<>(headers, HttpStatus.OK);
+            commonService.setHeader(response, newTokenDto);
+
+            return new ResponseEntity<>(HttpStatus.OK);
         } catch (Exception e) {
             return new ResponseEntity<>("Failed to refresh access token", HttpStatus.UNAUTHORIZED);
         }

--- a/src/main/java/com/team/leaf/user/account/dto/request/jwt/JwtJoinRequest.java
+++ b/src/main/java/com/team/leaf/user/account/dto/request/jwt/JwtJoinRequest.java
@@ -15,17 +15,13 @@ public class JwtJoinRequest {
     @NotBlank(message = "비밀번호 확인이 비어있습니다.")
     private String passwordCheck;
 
-    @NotBlank(message = "닉네임이 비어있습니다.")
-    private String nickname;
-
     @NotBlank(message = "핸드폰 번호가 비어있습니다.")
     private String phone;
 
-    public JwtJoinRequest(String email, String password, String passwordCheck, String nickname, String phone) {
+    public JwtJoinRequest(String email, String password, String passwordCheck, String phone) {
         this.email = email;
         this.password = password;
         this.passwordCheck = passwordCheck;
-        this.nickname = nickname;
         this.phone = phone;
     }
 

--- a/src/main/java/com/team/leaf/user/account/dto/request/jwt/JwtLoginRequest.java
+++ b/src/main/java/com/team/leaf/user/account/dto/request/jwt/JwtLoginRequest.java
@@ -10,4 +10,6 @@ public class JwtLoginRequest {
     private String email;
     private String password;
 
+    private Platform platform;
+
 }

--- a/src/main/java/com/team/leaf/user/account/dto/request/jwt/Platform.java
+++ b/src/main/java/com/team/leaf/user/account/dto/request/jwt/Platform.java
@@ -1,0 +1,7 @@
+package com.team.leaf.user.account.dto.request.jwt;
+
+public enum Platform {
+
+    FLUTTER, WEB
+
+}

--- a/src/main/java/com/team/leaf/user/account/dto/request/jwt/PlatformRequest.java
+++ b/src/main/java/com/team/leaf/user/account/dto/request/jwt/PlatformRequest.java
@@ -1,0 +1,10 @@
+package com.team.leaf.user.account.dto.request.jwt;
+
+import lombok.Getter;
+
+@Getter
+public class PlatformRequest {
+
+    Platform platform;
+
+}

--- a/src/main/java/com/team/leaf/user/account/dto/request/oauth/OAuthLoginRequest.java
+++ b/src/main/java/com/team/leaf/user/account/dto/request/oauth/OAuthLoginRequest.java
@@ -1,0 +1,15 @@
+package com.team.leaf.user.account.dto.request.oauth;
+
+import com.team.leaf.user.account.dto.request.jwt.Platform;
+import lombok.Getter;
+
+@Getter
+public class OAuthLoginRequest {
+
+    private String code;
+
+    private Platform platform;
+
+    private OAuth2LoginType type;
+
+}

--- a/src/main/java/com/team/leaf/user/account/entity/RefreshToken.java
+++ b/src/main/java/com/team/leaf/user/account/entity/RefreshToken.java
@@ -1,9 +1,7 @@
 package com.team.leaf.user.account.entity;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import com.team.leaf.user.account.dto.request.jwt.Platform;
+import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -22,6 +20,9 @@ public class RefreshToken {
     private String refreshToken;
     @NotBlank
     private String userEmail;
+
+    @Enumerated(EnumType.STRING)
+    private Platform platform;
 
     public RefreshToken(String token, String email) {
         this.refreshToken = token;

--- a/src/main/java/com/team/leaf/user/account/entity/RefreshToken.java
+++ b/src/main/java/com/team/leaf/user/account/entity/RefreshToken.java
@@ -4,6 +4,7 @@ import com.team.leaf.user.account.dto.request.jwt.Platform;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -17,12 +18,21 @@ public class RefreshToken {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long refreshId;
     @NotBlank
+    @Column(nullable = false)
     private String refreshToken;
     @NotBlank
+    @Column(nullable = false)
     private String userEmail;
 
     @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
     private Platform platform;
+
+    public RefreshToken(String token, String email, Platform platform) {
+        this.refreshToken = token;
+        this.userEmail = email;
+        this.platform = platform;
+    }
 
     public RefreshToken(String token, String email) {
         this.refreshToken = token;

--- a/src/main/java/com/team/leaf/user/account/jwt/JwtTokenFilter.java
+++ b/src/main/java/com/team/leaf/user/account/jwt/JwtTokenFilter.java
@@ -29,9 +29,8 @@ public class JwtTokenFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
 
-        String cookie_accessToken = getTokenByToken(request, "accessToken");
-        String cookie_refreshToken = getTokenByToken(request, "refreshToken");
-
+        String cookie_accessToken = getTokenByRequest(request, "accessToken");
+        String cookie_refreshToken = getTokenByRequest(request, "refreshToken");
         String accessToken = jwtTokenUtil.getHeaderToken(request, "Access");
         String refreshToken = jwtTokenUtil.getHeaderToken(request, "Refresh");
 
@@ -80,8 +79,8 @@ public class JwtTokenFilter extends OncePerRequestFilter {
         }
     }
 
-    public String getTokenByToken(HttpServletRequest request, String type) {
-        Cookie cookies[] = ((HttpServletRequest) request).getCookies();
+    public static String getTokenByRequest(HttpServletRequest request, String type) {
+        Cookie cookies[] = request.getCookies();
 
         if (cookies != null && cookies.length != 0) {
             return Arrays.stream(cookies)

--- a/src/main/java/com/team/leaf/user/account/jwt/JwtTokenFilter.java
+++ b/src/main/java/com/team/leaf/user/account/jwt/JwtTokenFilter.java
@@ -28,7 +28,6 @@ public class JwtTokenFilter extends OncePerRequestFilter {
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
-
         String cookie_accessToken = getTokenByRequest(request, "accessToken");
         String cookie_refreshToken = getTokenByRequest(request, "refreshToken");
         String accessToken = jwtTokenUtil.getHeaderToken(request, "Access");
@@ -45,7 +44,7 @@ public class JwtTokenFilter extends OncePerRequestFilter {
 
     private void processSecurity(String accessToken, String refreshToken, HttpServletResponse response) {
         if (accessToken != null) {
-            if (!jwtTokenUtil.tokenValidataion(accessToken)) {
+            if (!jwtTokenUtil.tokenValidation(accessToken)) {
                 jwtExceptionHandler(response, "AccessToken Expired", HttpStatus.BAD_REQUEST);
                 return;
             }
@@ -57,8 +56,10 @@ public class JwtTokenFilter extends OncePerRequestFilter {
         } else if (refreshToken != null) {
             if (!jwtTokenUtil.refreshTokenValidation(refreshToken)) {
                 jwtExceptionHandler(response, "RefreshToken Expired", HttpStatus.BAD_REQUEST);
+
                 return;
             }
+
             setAuthentication(jwtTokenUtil.getEmailFromToken(refreshToken));
         }
     }
@@ -73,7 +74,7 @@ public class JwtTokenFilter extends OncePerRequestFilter {
         response.setContentType("application/json");
         try {
             String json = new ObjectMapper().writeValueAsString(new GlobalResDto(msg, status.value()));
-            response.getWriter().write(json);
+            // response.getWriter().write(json);
         } catch (Exception e) {
             log.error(e.getMessage());
         }

--- a/src/main/java/com/team/leaf/user/account/jwt/JwtTokenUtil.java
+++ b/src/main/java/com/team/leaf/user/account/jwt/JwtTokenUtil.java
@@ -69,7 +69,7 @@ public class JwtTokenUtil {
                 .claim("role", role.name())
                 .setExpiration(new Date(date.getTime() + ACCESS_TIME))
                 .setIssuedAt(date)
-                .signWith(SignatureAlgorithm.HS256, key)
+                .signWith(key, SignatureAlgorithm.HS256)
                 .compact();
 
         String refreshToken = createRefreshToken(platform, email);
@@ -95,15 +95,14 @@ public class JwtTokenUtil {
                 .claim("role", role.name())
                 .setExpiration(new Date(date.getTime() + ACCESS_TIME))
                 .setIssuedAt(date)
-                .signWith(SignatureAlgorithm.HS256, key )
+                .signWith(key, SignatureAlgorithm.HS256)
                 .compact();
     }
 
     //refreshToken 검증
     public Boolean tokenValidation(String token) {
         try {
-            //Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
-            Jwts.parser().setSigningKey(token).parseClaimsJws(token);
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
 
             return true;
         } catch (SecurityException | MalformedJwtException e) {
@@ -158,7 +157,7 @@ public class JwtTokenUtil {
 
         //DB에 저장된 토큰 비교
         Optional<RefreshToken> refreshToken = refreshTokenRepository.findByRefreshTokenAndPlatformOrderByRefreshId(token, platform);
-
+        System.out.println("있나요? " + refreshToken.isPresent());
         return refreshToken.isPresent() && token.equals(refreshToken.get().getRefreshToken());
     }
 

--- a/src/main/java/com/team/leaf/user/account/jwt/JwtTokenUtil.java
+++ b/src/main/java/com/team/leaf/user/account/jwt/JwtTokenUtil.java
@@ -82,10 +82,6 @@ public class JwtTokenUtil {
     }
 
     public String recreateAccessToken(String refreshToken) {
-        if(!tokenValidation(refreshToken)) {
-            throw new RuntimeException("변조된 토큰입니다.");
-        }
-
         Date date = new Date();
         String email = getEmailFromToken(refreshToken);
         AccountRole role = getRoleFromEmail(email);

--- a/src/main/java/com/team/leaf/user/account/jwt/JwtTokenUtil.java
+++ b/src/main/java/com/team/leaf/user/account/jwt/JwtTokenUtil.java
@@ -70,6 +70,7 @@ public class JwtTokenUtil {
                 .compact();
 
         String refreshToken = Jwts.builder()
+                .setSubject(email)
                 .setExpiration(new Date(date.getTime() + REFRESH_TIME))
                 .setIssuedAt(date)
                 .signWith(SignatureAlgorithm.HS256, key)

--- a/src/main/java/com/team/leaf/user/account/jwt/JwtTokenUtil.java
+++ b/src/main/java/com/team/leaf/user/account/jwt/JwtTokenUtil.java
@@ -1,5 +1,7 @@
 package com.team.leaf.user.account.jwt;
 
+import com.team.leaf.user.account.dto.request.jwt.JwtLoginRequest;
+import com.team.leaf.user.account.dto.request.jwt.Platform;
 import com.team.leaf.user.account.dto.response.TokenDto;
 import com.team.leaf.user.account.entity.AccountDetail;
 import com.team.leaf.user.account.entity.AccountRole;
@@ -25,6 +27,7 @@ import java.security.Key;
 import java.time.Duration;
 import java.util.Base64;
 import java.util.Date;
+import java.util.List;
 import java.util.Optional;
 
 
@@ -40,8 +43,8 @@ public class JwtTokenUtil {
     //private static final String AUTHORITIES_KEY = "auth";
     public static final String ACCESS_TOKEN = "Authorization";
     public static final String REFRESH_TOKEN = "refresh_token";
-    private static final long ACCESS_TIME = Duration.ofMinutes(30).toMillis(); // 만료시간 30분
-    private static final long REFRESH_TIME = Duration.ofDays(14).toMillis(); // 만료시간 2주
+    public static final long ACCESS_TIME = Duration.ofMinutes(30).toMillis(); // 만료시간 30분
+    public static final long REFRESH_TIME = Duration.ofDays(14).toMillis(); // 만료시간 2주
 
     @Value("${jwt.secret}")
     private String secretKey;
@@ -57,7 +60,7 @@ public class JwtTokenUtil {
         return type.equals("Access") ? request.getHeader(ACCESS_TOKEN) : request.getHeader(REFRESH_TOKEN);
     }
 
-    public TokenDto createToken(String email) {
+    public TokenDto createToken(Platform platform, String email) {
         Date date = new Date();
         AccountRole role = getRoleFromEmail(email);
 
@@ -69,13 +72,7 @@ public class JwtTokenUtil {
                 .signWith(SignatureAlgorithm.HS256, key)
                 .compact();
 
-        String refreshToken = Jwts.builder()
-                .setSubject(email)
-                .setExpiration(new Date(date.getTime() + REFRESH_TIME))
-                .setIssuedAt(date)
-                .signWith(SignatureAlgorithm.HS256, key)
-                .compact();
-
+        String refreshToken = createRefreshToken(platform, email);
 
         return TokenDto.builder()
                 .accessToken(accessToken)
@@ -84,10 +81,28 @@ public class JwtTokenUtil {
                 .build();
     }
 
+    public String recreateAccessToken(String refreshToken) {
+        if(!tokenValidation(refreshToken)) {
+            throw new RuntimeException("변조된 토큰입니다.");
+        }
+        Date date = new Date();
+        String email = getEmailFromToken(refreshToken);
+        AccountRole role = getRoleFromEmail(email);
+
+        return Jwts.builder()
+                .setSubject(email)
+                .claim("role", role.name())
+                .setExpiration(new Date(date.getTime() + ACCESS_TIME))
+                .setIssuedAt(date)
+                .signWith(SignatureAlgorithm.HS256, key)
+                .compact();
+    }
+
     //refreshToken 검증
-    public Boolean tokenValidataion(String token) {
+    public Boolean tokenValidation(String token) {
         try {
             Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+
             return true;
         } catch (SecurityException | MalformedJwtException e) {
             log.error("Invalid JWT signature");
@@ -107,10 +122,32 @@ public class JwtTokenUtil {
         }
     }
 
-    public Boolean refreshTokenValidation(String token) {
+    public String createRefreshToken(Platform platform, String email) {
+        List<RefreshToken> refreshToken = refreshTokenRepository.findByUserEmailAndPlatformOrderByRefreshId(email, platform);
+        Date date = new Date();
 
+        if(platform == Platform.FLUTTER) {
+            if(refreshToken.size() >= 3) {
+                refreshTokenRepository.delete(refreshToken.get(0));
+            }
+        }
+        else if(platform == Platform.WEB) {
+            if(refreshToken.size() >= 1) {
+                refreshTokenRepository.delete(refreshToken.get(0));
+            }
+        }
+
+        return Jwts.builder()
+                .setSubject(email)
+                .setExpiration(new Date(date.getTime() + REFRESH_TIME))
+                .setIssuedAt(date)
+                .signWith(SignatureAlgorithm.HS256, key)
+                .compact();
+    }
+
+    public Boolean refreshTokenValidation(String token) {
         //1차 검증
-        if (!tokenValidataion(token)) return false;
+        if (!tokenValidation(token)) return false;
 
         //DB에 저장된 토큰 비교
         Optional<RefreshToken> refreshToken = refreshTokenRepository.findByUserEmail(getEmailFromToken(token));

--- a/src/main/java/com/team/leaf/user/account/jwt/JwtTokenUtil.java
+++ b/src/main/java/com/team/leaf/user/account/jwt/JwtTokenUtil.java
@@ -157,7 +157,7 @@ public class JwtTokenUtil {
 
         //DB에 저장된 토큰 비교
         Optional<RefreshToken> refreshToken = refreshTokenRepository.findByRefreshTokenAndPlatformOrderByRefreshId(token, platform);
-        System.out.println("있나요? " + refreshToken.isPresent());
+
         return refreshToken.isPresent() && token.equals(refreshToken.get().getRefreshToken());
     }
 

--- a/src/main/java/com/team/leaf/user/account/jwt/JwtTokenUtil.java
+++ b/src/main/java/com/team/leaf/user/account/jwt/JwtTokenUtil.java
@@ -38,7 +38,7 @@ public class JwtTokenUtil {
     private final AccountRepository accountRepository;
     private final OAuth2Repository oAuth2Repository;
     //private static final String AUTHORITIES_KEY = "auth";
-    public static final String ACCESS_TOKEN = "access_token";
+    public static final String ACCESS_TOKEN = "Authorization";
     public static final String REFRESH_TOKEN = "refresh_token";
     private static final long ACCESS_TIME = Duration.ofMinutes(30).toMillis(); // 만료시간 30분
     private static final long REFRESH_TIME = Duration.ofDays(14).toMillis(); // 만료시간 2주

--- a/src/main/java/com/team/leaf/user/account/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/team/leaf/user/account/repository/RefreshTokenRepository.java
@@ -10,8 +10,12 @@ import java.util.Optional;
 
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
 
-    Optional<RefreshToken> findByUserEmail (String userEmail);
+    Optional<RefreshToken> findByUserEmailAndRefreshToken(String userEmail, String refreshToken);
 
     List<RefreshToken> findByUserEmailAndPlatformOrderByRefreshId(String userEmail, Platform platform);
+
+    Optional<RefreshToken> findByRefreshTokenAndPlatformOrderByRefreshId(String refreshToken, Platform platform);
+
+    void deleteByRefreshToken(String refreshToken);
 
 }

--- a/src/main/java/com/team/leaf/user/account/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/team/leaf/user/account/repository/RefreshTokenRepository.java
@@ -1,12 +1,17 @@
 package com.team.leaf.user.account.repository;
 
+import com.team.leaf.user.account.dto.request.jwt.Platform;
 import com.team.leaf.user.account.entity.RefreshToken;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.sql.Ref;
+import java.util.List;
 import java.util.Optional;
 
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
 
     Optional<RefreshToken> findByUserEmail (String userEmail);
+
+    List<RefreshToken> findByUserEmailAndPlatformOrderByRefreshId(String userEmail, Platform platform);
 
 }

--- a/src/main/java/com/team/leaf/user/account/service/AccountService.java
+++ b/src/main/java/com/team/leaf/user/account/service/AccountService.java
@@ -68,14 +68,31 @@ public class AccountService {
         }
 
         // 닉네임 중복 체크
-        if (accountRepository.existsByNickname(request.getNickname())) {
-            throw new RuntimeException("이미 존재하는 닉네임입니다.");
-        }
+        String nickName = createNickName(request.getEmail());
 
-        AccountDetail accountDetail = AccountDetail.joinAccount(request.getEmail(),jwtSecurityConfig.passwordEncoder().encode(request.getPassword()), request.getPhone(), request.getNickname());
+        AccountDetail accountDetail = AccountDetail.joinAccount(request.getEmail(),jwtSecurityConfig.passwordEncoder().encode(request.getPassword()), request.getPhone(), nickName);
         accountRepository.save(accountDetail);
         return "Success Join";
+    }
 
+    private String createNickName(String email) {
+        while(true) {
+            String random = generateRandomNumber(7);
+
+            String randomNickName = email.substring(0 , 4) + random;
+            if(!accountRepository.existsByNickname(randomNickName)) {
+                return randomNickName;
+            }
+        }
+    }
+
+    private String generateRandomNumber(int N) {
+        String result = "";
+        for(int i = 0; i < N; i++) {
+            result += Integer.toString((int) ((Math.random()*10000)%10));
+        }
+
+        return result;
     }
 
     public String joinWithAdditionalInfo(AdditionalJoinInfoRequest request) {

--- a/src/main/java/com/team/leaf/user/account/service/AccountService.java
+++ b/src/main/java/com/team/leaf/user/account/service/AccountService.java
@@ -224,12 +224,12 @@ public class AccountService {
     }
 
     @Transactional
-    public TokenDto refreshAccessToken(String accessToken, String refreshToken) {
+    public TokenDto refreshAccessToken(String refreshToken) {
         if (!jwtTokenUtil.tokenValidataion(refreshToken)) {
             throw new RuntimeException("Invalid Refresh Token");
         }
 
-        String email = jwtTokenUtil.getEmailFromToken(accessToken);
+        String email = jwtTokenUtil.getEmailFromToken(refreshToken);
 
         String getRefreshToken = (String)redisTemplate.opsForValue().get("RT:" + email);
 

--- a/src/main/java/com/team/leaf/user/account/service/CommonService.java
+++ b/src/main/java/com/team/leaf/user/account/service/CommonService.java
@@ -78,10 +78,15 @@ public class CommonService {
     }
 
     public void setHeader(HttpServletResponse response, TokenDto tokenDto) {
-        response.addHeader(JwtTokenUtil.ACCESS_TOKEN, tokenDto.getAccessToken());
-        response.addHeader(JwtTokenUtil.REFRESH_TOKEN, tokenDto.getRefreshToken());
-        response.addHeader("Set-Cookie", createAccessToken(tokenDto.getAccessToken()).toString());
-        response.addHeader("Set-Cookie", createRefreshToken(tokenDto.getRefreshToken()).toString());
+        if(tokenDto.getRefreshToken() != null) {
+            response.addHeader(JwtTokenUtil.REFRESH_TOKEN, tokenDto.getRefreshToken());
+            response.addHeader("Set-Cookie", createRefreshToken(tokenDto.getRefreshToken()).toString());
+        }
+
+        if(tokenDto.getAccessToken() != null) {
+            response.addHeader(JwtTokenUtil.ACCESS_TOKEN, tokenDto.getAccessToken());
+            response.addHeader("Set-Cookie", createAccessToken(tokenDto.getAccessToken()).toString());
+        }
     }
 
     public static ResponseCookie createAccessToken(String access) {

--- a/src/main/java/com/team/leaf/user/account/service/CommonService.java
+++ b/src/main/java/com/team/leaf/user/account/service/CommonService.java
@@ -9,6 +9,7 @@ import com.team.leaf.user.account.repository.AccountRepository;
 import com.team.leaf.user.account.repository.OAuth2Repository;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Service;
 
 import java.util.Optional;
@@ -79,6 +80,30 @@ public class CommonService {
     public void setHeader(HttpServletResponse response, TokenDto tokenDto) {
         response.addHeader(JwtTokenUtil.ACCESS_TOKEN, tokenDto.getAccessToken());
         response.addHeader(JwtTokenUtil.REFRESH_TOKEN, tokenDto.getRefreshToken());
+        response.addHeader("Set-Cookie", createAccessToken(tokenDto.getAccessToken()).toString());
+        response.addHeader("Set-Cookie", createRefreshToken(tokenDto.getRefreshToken()).toString());
+    }
+
+    public static ResponseCookie createAccessToken(String access) {
+        return ResponseCookie.from("accessToken" , access)
+                .path("/")
+                .maxAge(30 * 60 * 1000)
+                //.secure(true)
+                //.domain()
+                .httpOnly(true)
+                //.sameSite("none")
+                .build();
+    }
+
+    public static ResponseCookie createRefreshToken(String refresh) {
+        return ResponseCookie.from("refreshToken" , refresh)
+                .path("/")
+                .maxAge(14 * 24 * 60 * 60 * 1000)
+                //.secure(true)
+                //.domain()
+                .httpOnly(true)
+                //.sameSite("none")
+                .build();
     }
 
 }

--- a/src/main/java/com/team/leaf/user/account/service/WebOAuth2Service.java
+++ b/src/main/java/com/team/leaf/user/account/service/WebOAuth2Service.java
@@ -38,7 +38,6 @@ public class WebOAuth2Service {
     private final RefreshTokenRepository refreshTokenRepository;
     private final CommonService commonService;
     private final List<OAuth2LoginInfo> oAuth2LoginInfoList;
-    private final AuthenticationManagerBuilder authenticationManagerBuilder;
     private final RedisTemplate redisTemplate;
 
     /*public ResponseEntity<String> requestAccessToken(OAUth2LoginType type, String code) {
@@ -110,7 +109,7 @@ public class WebOAuth2Service {
     }
 
     @Transactional
-    public String logout(String accessToken) {
+    public String logout(String accessToken, String refreshToken) {
         if(!jwtTokenUtil.tokenValidation(accessToken)) {
             throw new IllegalArgumentException("Invalid Access Token");
         }
@@ -123,7 +122,7 @@ public class WebOAuth2Service {
 
         Long expiration = jwtTokenUtil.getExpiration(accessToken);
         redisTemplate.opsForValue().set(accessToken, "logout", expiration, TimeUnit.MILLISECONDS);
-
+        refreshTokenRepository.deleteByRefreshToken(refreshToken);
 
         return "Success Logout";
     }

--- a/src/main/java/com/team/leaf/user/account/service/WebOAuth2Service.java
+++ b/src/main/java/com/team/leaf/user/account/service/WebOAuth2Service.java
@@ -1,7 +1,9 @@
 package com.team.leaf.user.account.service;
 
+import com.team.leaf.user.account.dto.request.jwt.Platform;
 import com.team.leaf.user.account.dto.request.oauth.OAuth2LoginType;
 import com.team.leaf.user.account.dto.request.oauth.OAuth2TokenDto;
+import com.team.leaf.user.account.dto.request.oauth.OAuthLoginRequest;
 import com.team.leaf.user.account.dto.response.OAuth2LoginResponse;
 import com.team.leaf.user.account.dto.response.TokenDto;
 import com.team.leaf.user.account.entity.AccountRole;
@@ -23,6 +25,8 @@ import org.springframework.util.ObjectUtils;
 
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+
+import static com.team.leaf.user.account.jwt.JwtTokenUtil.REFRESH_TIME;
 
 @Service
 @Slf4j
@@ -49,9 +53,9 @@ public class WebOAuth2Service {
                 .orElseThrow(() -> new AccountException("알 수 없는 로그인 타입입니다."));
     }
 
-    public OAuth2LoginResponse oAuth2Login(OAuth2LoginType type, String code, HttpServletResponse response) {
-        OAuth2LoginInfo oAuth2LoginInfo = findOAuth2LoginType(type);
-        ResponseEntity<String> accessTokenRes = oAuth2LoginInfo.requestAccessToken(code);
+    public OAuth2LoginResponse oAuth2Login(OAuthLoginRequest request, HttpServletResponse response) {
+        OAuth2LoginInfo oAuth2LoginInfo = findOAuth2LoginType(request.getType());
+        ResponseEntity<String> accessTokenRes = oAuth2LoginInfo.requestAccessToken(request.getCode());
 
         OAuth2TokenDto oAuth2Token = oAuth2LoginInfo.getAccessToken(accessTokenRes);
 
@@ -67,11 +71,11 @@ public class WebOAuth2Service {
         if(existOwner == null) {
             log.info("첫 로그인 회원");
             oAuth2Account.setRole(AccountRole.USER);
-            oAuth2Account.setSocialType(type);
+            oAuth2Account.setSocialType(request.getType());
             oAuth2Repository.save(oAuth2Account);
         }
 
-        TokenDto tokenDto = jwtTokenUtil.createToken(oAuth2Account.getEmail());
+        TokenDto tokenDto = jwtTokenUtil.createToken(request.getPlatform(), oAuth2Account.getEmail());
 
         redisTemplate.opsForValue().set("RT:" + oAuth2Account.getEmail(), tokenDto.getRefreshToken(), tokenDto.getRefreshTokenExpirationTime(), TimeUnit.MILLISECONDS);
 
@@ -81,12 +85,12 @@ public class WebOAuth2Service {
     }
 
     @Transactional
-    public TokenDto refreshAccessToken(String accessToken, String refreshToken) {
-        if (!jwtTokenUtil.tokenValidataion(refreshToken)) {
+    public TokenDto refreshAccessToken(String refreshToken) {
+        if (!jwtTokenUtil.tokenValidation(refreshToken)) {
             throw new RuntimeException("Invalid Refresh Token");
         }
 
-        String email = jwtTokenUtil.getEmailFromToken(accessToken);
+        String email = jwtTokenUtil.getEmailFromToken(refreshToken);
 
         String getRefreshToken = (String)redisTemplate.opsForValue().get("RT:" + email);
 
@@ -97,17 +101,17 @@ public class WebOAuth2Service {
             throw new IllegalArgumentException("Refresh Token 정보가 일치하지 않습니다");
         }
 
-        TokenDto tokenDto = jwtTokenUtil.createToken(email);
+        String new_refreshToken = jwtTokenUtil.recreateAccessToken(email);
 
 
-        redisTemplate.opsForValue().set("RT:" + email, tokenDto.getRefreshToken(), tokenDto.getRefreshTokenExpirationTime(), TimeUnit.MILLISECONDS);
+        redisTemplate.opsForValue().set("RT:" + email, new_refreshToken, REFRESH_TIME, TimeUnit.MILLISECONDS);
 
-        return tokenDto;
+        return TokenDto.builder().refreshToken(new_refreshToken).refreshTokenExpirationTime(REFRESH_TIME).build();
     }
 
     @Transactional
     public String logout(String accessToken) {
-        if(!jwtTokenUtil.tokenValidataion(accessToken)) {
+        if(!jwtTokenUtil.tokenValidation(accessToken)) {
             throw new IllegalArgumentException("Invalid Access Token");
         }
 

--- a/src/main/java/com/team/leaf/user/account/service/WebOAuth2Service.java
+++ b/src/main/java/com/team/leaf/user/account/service/WebOAuth2Service.java
@@ -84,8 +84,8 @@ public class WebOAuth2Service {
     }
 
     @Transactional
-    public TokenDto refreshAccessToken(String refreshToken) {
-        if (!jwtTokenUtil.tokenValidation(refreshToken)) {
+    public TokenDto refreshAccessToken(Platform platform, String refreshToken) {
+        if (!jwtTokenUtil.refreshTokenValidation(refreshToken, platform)) {
             throw new RuntimeException("Invalid Refresh Token");
         }
 

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -17,13 +17,13 @@ spring:
   jpa:
     database: mysql
     database-platform: org.hibernate.dialect.MySQLDialect
-    show-sql: true
+#    show-sql: true
     hibernate:
       ddl-auto: update
-    properties:
-      hibernate:
-        show_sql: true
-        format_sql: true
+#    properties:
+#      hibernate:
+#        show_sql: true
+#        format_sql: true
 
   #social
   security:


### PR DESCRIPTION
## ✔ 지라 이슈 번호



## 📒 작업 내용

문제 1 :   자동 로그인 해제 문제 Flutter 는 3개까지 ( UUID 전송 ) , 웹은 최대 1개의 브라우저까지만 적용 ( UUID 미 전송 )
      구현 1 : 플러터는 총 3개의 RefreshToken 을 적용 ( Platform 과 Email 로 구분 )
      구현 2 : 웹은 총 1개의 RefreshToken 을 적용 ( Platform 과 Email 로 구분 )
      구현 3 : 갯수가 초과될 경우 마지막 R 토큰을 제거  ( A 토큰은 살아있음 )
문제 2 :  백엔드 서버에서 이메일 앞 4자리 + 임의 숫자 7개를 조합하여 닉네임 생성.
문제 3 :  R 토큰만으로 A 토큰을 교체할 수 있게
      구현 : access_token 헤더명을 Authorization 으로 고정 ( refresh_token은 그대로 사용 )
문제 4 :  헤더 쿠키 문제 - Authorization 헤더에 없으면 Cookie 를 사용하여 토큰 정보 가져오기

## 📢 리뷰어에게 하고 싶은 말
ex) 어디어디를 중점적으로 봐주세요 ...


## 📌 PR 전 체크 사항
- [ ] base 브랜치 ( PR 대상 ) 이/가 **develop** 브랜치로 되어있나요?
- [ ] PR title에 PR Type을 표시해 두었나요? (feat:, fix:, refact: ...) [참고 블로그](https://velog.io/@shin6403/Git-git-%EC%BB%A4%EB%B0%8B-%EC%BB%A8%EB%B2%A4%EC%85%98-%EC%84%A4%EC%A0%95%ED%95%98%EA%B8%B0)
- [ ] feature 브랜치에서 작업 하셨나요?